### PR TITLE
[menu_mobile] Décline une version accordion

### DIFF
--- a/web/app/themes/wwp_child_theme/assets/raw/scss/menus/_menu_mobile.scss
+++ b/web/app/themes/wwp_child_theme/assets/raw/scss/menus/_menu_mobile.scss
@@ -7,6 +7,7 @@
 /* ------------- */
 $mobileheaderHeight: 80px;
 $header-bg-color: #ffffff;
+$menu-item-height: 60px;
 $menu-item-color: $color-base;
 $menu-item-bgcolor: $gray-200;
 $menu-item-color-active: $color-base;
@@ -57,7 +58,7 @@ $menu-item-m0-color: $color-base;
     /*overflow-x: hidden;*/
 
     li {
-      height: 60px;
+      height: $menu-item-height;
       margin-left: 0;
       font-size: 1.5rem;
       line-height: 2rem;
@@ -126,7 +127,7 @@ $menu-item-m0-color: $color-base;
 
     ul.mobile-nav-links {
       display: grid;
-      grid-template-columns: 60px 1fr;
+      grid-template-columns: $menu-item-height 1fr;
       margin-left: 0;
     }
 
@@ -139,6 +140,7 @@ $menu-item-m0-color: $color-base;
         width: 100%;
         margin-top: 0;
         margin-bottom: 0;
+        padding: 0;
         background-color: #ffffff;
         text-indent: -999px;
         border-bottom: 0 !important;

--- a/web/app/themes/wwp_child_theme/assets/raw/scss/menus/menu_mobile_accordion/_menu_mobile_accordion.scss
+++ b/web/app/themes/wwp_child_theme/assets/raw/scss/menus/menu_mobile_accordion/_menu_mobile_accordion.scss
@@ -1,0 +1,75 @@
+/*MENU MOBILE ACCORDION*/
+//Pour activer cette forme, ajouter la classe .menu-mobile-accordion à .navigation-wrapper
+
+/* Variables */
+$menu-item-height: 60px;
+$menu-item-bgcolor-active: $gray-400;
+
+@media (max-width: $medium - 1) {
+
+  .navigation-wrapper.menu-mobile-accordion {
+    height: auto;
+
+    ul.header-menu {
+      height: auto;
+
+      li {
+        height: auto;
+
+        > a {
+          justify-content: center;
+          height: $menu-item-height;
+        }
+      }
+
+      li.page_item_has_children {
+        height: auto;
+
+        > a {
+          flex-direction: row;
+          justify-content: center;
+          font-size: 1.6rem;
+          background-color: $menu-item-bgcolor-active;
+        }
+
+        > a::after {
+          position: static;
+          width: 20px;
+          height: 20px;
+          margin-top: -3px;
+          margin-left: 1rem;
+          background-image: url("/app/themes/wwp_child_theme/assets/raw/svg/plus.svg");
+          transform: rotate(0deg);
+        }
+      }
+
+      li.m0 {
+
+        > a {
+          text-transform: uppercase;
+          font-weight: $weight-bold;
+        }
+      }
+
+      ul.children {
+        display: initial;
+        position: initial;
+        height: auto;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: all !important;
+        transform: none !important;
+      }
+
+      ul.mobile-nav-links {
+        display: none;
+      }
+
+      //ANIMATIONS
+      li.page_item_has_children.is-opened > a::after {
+        transform: rotate(45deg);
+      }
+    }
+  }
+}
+

--- a/web/app/themes/wwp_child_theme/assets/raw/scss/theme.scss
+++ b/web/app/themes/wwp_child_theme/assets/raw/scss/theme.scss
@@ -1,6 +1,7 @@
 @import '../../../styleguide/scss/main';
 
 @import 'menus/menu_mobile';
+@import "menus/menu_mobile_accordion/menu_mobile_accordion";
 
 @import '/../../../includes/Components/components';
 

--- a/web/app/themes/wwp_child_theme/assets/raw/svg/plus-grey.svg
+++ b/web/app/themes/wwp_child_theme/assets/raw/svg/plus-grey.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#928F88;}
+</style>
+<rect x="8.9" y="1.3" class="st0" width="1.6" height="17"/>
+<rect x="9" y="1.3" transform="matrix(6.123234e-17 -1 1 6.123234e-17 1.253833e-02 19.608)" class="st0" width="1.6" height="17"/>
+</svg>

--- a/web/app/themes/wwp_child_theme/assets/raw/svg/plus.svg
+++ b/web/app/themes/wwp_child_theme/assets/raw/svg/plus.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve">
+<polygon points="18.2,8.9 11.2,8.9 11.2,2 8.9,2 8.9,8.9 2,8.9 2,11.2 8.9,11.2 8.9,18.2 11.2,18.2 11.2,11.2 18.2,11.2 "/>
+</svg>


### PR DESCRIPTION
Pour activer cette variante, ajouter la classe .menu-mobile-accordion à .navigation-wrapper. Sans JS tous les menus sont ouverts.